### PR TITLE
change status messages to be more clear and scale with screen size

### DIFF
--- a/static/client.html
+++ b/static/client.html
@@ -88,14 +88,17 @@
 
     body.winner p#status::before {
       content: "YOU WON!";
+      font-size: min(4vw, 200%);
     }
 
     body.polling p#status::before {
       content: "Polling";
+      font-size: min(4vw, 200%);
     }
 
     body.error p#status::before {
       content: "Error: No such session or unable to establish connection.";
+      font-size: min(4vw, 200%);
     }
 
     button {

--- a/static/client.html
+++ b/static/client.html
@@ -13,7 +13,7 @@
 
     body {
       margin: 0;
-      padding: 1em;
+      padding: 0;
       height: 100%;
       box-sizing: border-box;
       font-family: sans-serif;
@@ -56,7 +56,7 @@
 
     input#idinput {
       text-align: center;
-      font-size: 400%;
+      font-size: min(20vw, 400%);
       border: 0.1em solid grey;
       border-radius: 0.2em;
       padding: 0.1em 0.3em;
@@ -73,14 +73,17 @@
     body:not(.connected) p#nvotes::before {
       content: "Enter 4-character Poll ID";
       font-weight: normal;
+      font-size: min(8vw, 200%);
     }
 
     body:not(.connected) p#status::before {
-      content: "Disconnected";
+      content: "No Session (yet)";
+      font-size: min(8vw, 200%);
     }
 
     body.connected p#status::before {
-      content: "Connected";
+      content: "Connected. Please wait for the poll to start.";
+      font-size: min(4vw, 200%);
     }
 
     body.winner p#status::before {
@@ -92,7 +95,7 @@
     }
 
     body.error p#status::before {
-      content: "Error";
+      content: "Error: No such session or unable to establish connection.";
     }
 
     button {


### PR DESCRIPTION
Just a few tweaks to the CSS in client.html to make the text a bit more verbose so users actually know what is going on ("Connected." "Disconnected." doesn't really explain the state) and make the text size scale with viewport width so users never have to swipe around to center the input.